### PR TITLE
Fix print start/end times for local timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,5 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Convert print start/end times from UTC timestamps to the Home Assistant local timezone so they match the header clock.
-- Treat ISO-format Bambu timestamps without an explicit offset as UTC, and derive end time from remaining duration when a print is active so it matches the ETA.
+- Derive end time from `now + remaining` during active prints so it matches the ETA, using the same unit conversion as the ETA label.
 - Capture print start time on the CYD when print status first switches to Preparing or Running, instead of using the unreliable Bambu `start_time` sensor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+- Convert print start/end times from UTC timestamps to the Home Assistant local timezone so they match the header clock.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Convert print start/end times from UTC timestamps to the Home Assistant local timezone so they match the header clock.
+- Treat ISO-format Bambu timestamps without an explicit offset as UTC, and derive end time from remaining duration when a print is active so it matches the ETA.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ All notable changes to this project will be documented in this file.
 
 - Convert print start/end times from UTC timestamps to the Home Assistant local timezone so they match the header clock.
 - Treat ISO-format Bambu timestamps without an explicit offset as UTC, and derive end time from remaining duration when a print is active so it matches the ETA.
+- Capture print start time on the CYD when print status first switches to Preparing or Running, instead of using the unreliable Bambu `start_time` sensor.

--- a/packages/cyd-dashboard.yaml
+++ b/packages/cyd-dashboard.yaml
@@ -195,6 +195,21 @@ globals:
     restore_value: no
     initial_value: 'false'
 
+  - id: captured_start_valid
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: captured_start_hour
+    type: uint8_t
+    restore_value: no
+    initial_value: '0'
+
+  - id: captured_start_minute
+    type: uint8_t
+    restore_value: no
+    initial_value: '0'
+
   - id: palette_bg_color
     type: uint32_t
     restore_value: no
@@ -544,6 +559,43 @@ text_sensor:
     id: printer_status
     entity_id: ${printer_state_entity}
     internal: true
+    on_value:
+      then:
+        - lambda: |-
+            std::string s = x;
+            for (char &c : s) {
+              if (c >= 'A' && c <= 'Z') {
+                c = static_cast<char>(c - 'A' + 'a');
+              }
+            }
+
+            const bool is_active =
+                s.find("prepar") != std::string::npos ||
+                s.find("running") != std::string::npos;
+
+            const bool is_finished =
+                s.empty() || s == "unknown" || s == "unavailable" ||
+                s.find("idle") != std::string::npos ||
+                s.find("finish") != std::string::npos ||
+                s.find("complete") != std::string::npos ||
+                s.find("failed") != std::string::npos ||
+                s.find("cancel") != std::string::npos ||
+                s.find("offline") != std::string::npos;
+
+            if (is_finished) {
+              id(captured_start_valid) = false;
+              return;
+            }
+
+            if (is_active && !id(captured_start_valid)) {
+              auto now = id(ha_time).now();
+              if (now.is_valid()) {
+                id(captured_start_hour) = now.hour;
+                id(captured_start_minute) = now.minute;
+                id(captured_start_valid) = true;
+              }
+            }
+        - script.execute: refresh_ui
 
   - platform: homeassistant
     id: printer_start_time
@@ -581,78 +633,10 @@ text_sensor:
     internal: true
     update_interval: 1s
     lambda: |-
-      const std::string raw = id(printer_start_time).state;
-      if (raw.empty() || raw == "unknown" || raw == "unavailable") {
-        return std::string("--");
-      }
-
-      std::string s = raw;
-      for (char &c : s) {
-        if (c == 'T') {
-          c = ' ';
-        }
-      }
-
-      const size_t dot = s.find('.');
-      if (dot != std::string::npos) {
-        s = s.substr(0, dot);
-      }
-
-      bool is_utc = false;
-      if (!s.empty() && s.back() == 'Z') {
-        is_utc = true;
-        s.pop_back();
-        while (!s.empty() && s.back() == ' ') {
-          s.pop_back();
-        }
-      }
-      if (s.size() >= 6) {
-        const size_t pos = s.size() - 6;
-        const char sign = s[pos];
-        if ((sign == '+' || sign == '-') &&
-            s[pos + 1] >= '0' && s[pos + 1] <= '9' &&
-            s[pos + 2] >= '0' && s[pos + 2] <= '9' &&
-            s[pos + 3] == ':' &&
-            s[pos + 4] >= '0' && s[pos + 4] <= '9' &&
-            s[pos + 5] >= '0' && s[pos + 5] <= '9') {
-          is_utc = true;
-          s = s.substr(0, pos);
-          while (!s.empty() && s.back() == ' ') {
-            s.pop_back();
-          }
-        }
-      }
-      if (!is_utc && s.size() >= 10 && s[4] == '-' && s[7] == '-' &&
-          s[0] >= '0' && s[0] <= '9') {
-        is_utc = true;
-      }
-
-      ESPTime parsed;
-      if (ESPTime::strptime(s, parsed)) {
-        if (is_utc && parsed.year >= 2019) {
-          parsed.recalc_timestamp_utc();
-          if (parsed.timestamp >= 0) {
-            const ESPTime local = ESPTime::from_epoch_local(parsed.timestamp);
-            char buf[8];
-            snprintf(buf, sizeof(buf), "%02d:%02d", local.hour, local.minute);
-            return std::string(buf);
-          }
-        }
+      if (id(captured_start_valid)) {
         char buf[8];
-        snprintf(buf, sizeof(buf), "%02d:%02d", parsed.hour, parsed.minute);
+        snprintf(buf, sizeof(buf), "%02d:%02d", id(captured_start_hour), id(captured_start_minute));
         return std::string(buf);
-      }
-
-      auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-      const size_t colon = s.find(':');
-      if (colon != std::string::npos && colon + 2 < s.size() &&
-          is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
-        if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
-          return s.substr(colon - 2, 5);
-        }
-        if (colon >= 1 && is_digit(s[colon - 1])) {
-          return std::string("0") + s.substr(colon - 1, 4);
-        }
       }
       return std::string("--");
 

--- a/packages/cyd-dashboard.yaml
+++ b/packages/cyd-dashboard.yaml
@@ -577,6 +577,158 @@ text_sensor:
     internal: true
 
   - platform: template
+    id: printer_start_time_display
+    internal: true
+    update_interval: 1s
+    lambda: |-
+      const std::string raw = id(printer_start_time).state;
+      if (raw.empty() || raw == "unknown" || raw == "unavailable") {
+        return std::string("--");
+      }
+
+      std::string s = raw;
+      for (char &c : s) {
+        if (c == 'T') {
+          c = ' ';
+        }
+      }
+
+      const size_t dot = s.find('.');
+      if (dot != std::string::npos) {
+        s = s.substr(0, dot);
+      }
+
+      bool is_utc = false;
+      if (!s.empty() && s.back() == 'Z') {
+        is_utc = true;
+        s.pop_back();
+        while (!s.empty() && s.back() == ' ') {
+          s.pop_back();
+        }
+      }
+      if (s.size() >= 6) {
+        const size_t pos = s.size() - 6;
+        const char sign = s[pos];
+        if ((sign == '+' || sign == '-') &&
+            s[pos + 1] >= '0' && s[pos + 1] <= '9' &&
+            s[pos + 2] >= '0' && s[pos + 2] <= '9' &&
+            s[pos + 3] == ':' &&
+            s[pos + 4] >= '0' && s[pos + 4] <= '9' &&
+            s[pos + 5] >= '0' && s[pos + 5] <= '9') {
+          is_utc = true;
+          s = s.substr(0, pos);
+          while (!s.empty() && s.back() == ' ') {
+            s.pop_back();
+          }
+        }
+      }
+
+      ESPTime parsed;
+      if (ESPTime::strptime(s, parsed)) {
+        if (is_utc && parsed.year >= 2019) {
+          parsed.recalc_timestamp_utc();
+          if (parsed.timestamp >= 0) {
+            const ESPTime local = ESPTime::from_epoch_local(parsed.timestamp);
+            char buf[8];
+            snprintf(buf, sizeof(buf), "%02d:%02d", local.hour, local.minute);
+            return std::string(buf);
+          }
+        }
+        char buf[8];
+        snprintf(buf, sizeof(buf), "%02d:%02d", parsed.hour, parsed.minute);
+        return std::string(buf);
+      }
+
+      auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
+      const size_t colon = s.find(':');
+      if (colon != std::string::npos && colon + 2 < s.size() &&
+          is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
+        if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
+          return s.substr(colon - 2, 5);
+        }
+        if (colon >= 1 && is_digit(s[colon - 1])) {
+          return std::string("0") + s.substr(colon - 1, 4);
+        }
+      }
+      return std::string("--");
+
+  - platform: template
+    id: printer_end_time_display
+    internal: true
+    update_interval: 1s
+    lambda: |-
+      const std::string raw = id(printer_end_time).state;
+      if (raw.empty() || raw == "unknown" || raw == "unavailable") {
+        return std::string("--");
+      }
+
+      std::string s = raw;
+      for (char &c : s) {
+        if (c == 'T') {
+          c = ' ';
+        }
+      }
+
+      const size_t dot = s.find('.');
+      if (dot != std::string::npos) {
+        s = s.substr(0, dot);
+      }
+
+      bool is_utc = false;
+      if (!s.empty() && s.back() == 'Z') {
+        is_utc = true;
+        s.pop_back();
+        while (!s.empty() && s.back() == ' ') {
+          s.pop_back();
+        }
+      }
+      if (s.size() >= 6) {
+        const size_t pos = s.size() - 6;
+        const char sign = s[pos];
+        if ((sign == '+' || sign == '-') &&
+            s[pos + 1] >= '0' && s[pos + 1] <= '9' &&
+            s[pos + 2] >= '0' && s[pos + 2] <= '9' &&
+            s[pos + 3] == ':' &&
+            s[pos + 4] >= '0' && s[pos + 4] <= '9' &&
+            s[pos + 5] >= '0' && s[pos + 5] <= '9') {
+          is_utc = true;
+          s = s.substr(0, pos);
+          while (!s.empty() && s.back() == ' ') {
+            s.pop_back();
+          }
+        }
+      }
+
+      ESPTime parsed;
+      if (ESPTime::strptime(s, parsed)) {
+        if (is_utc && parsed.year >= 2019) {
+          parsed.recalc_timestamp_utc();
+          if (parsed.timestamp >= 0) {
+            const ESPTime local = ESPTime::from_epoch_local(parsed.timestamp);
+            char buf[8];
+            snprintf(buf, sizeof(buf), "%02d:%02d", local.hour, local.minute);
+            return std::string(buf);
+          }
+        }
+        char buf[8];
+        snprintf(buf, sizeof(buf), "%02d:%02d", parsed.hour, parsed.minute);
+        return std::string(buf);
+      }
+
+      auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
+      const size_t colon = s.find(':');
+      if (colon != std::string::npos && colon + 2 < s.size() &&
+          is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
+        if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
+          return s.substr(colon - 2, 5);
+        }
+        if (colon >= 1 && is_digit(s[colon - 1])) {
+          return std::string("0") + s.substr(colon - 1, 4);
+        }
+      }
+      return std::string("--");
+
+  - platform: template
     id: touch_last_position
     name: "${friendly_name} Last Touch"
     icon: mdi:gesture-tap
@@ -1849,46 +2001,12 @@ script:
       - lvgl.label.update:
           id: start_value
           text: !lambda |-
-            if (id(printer_start_time).state.empty() || id(printer_start_time).state == "unknown" || id(printer_start_time).state == "unavailable") {
-              return std::string("--");
-            }
-            std::string s = id(printer_start_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = s.find(':');
-            if (colon != std::string::npos && colon + 2 < s.size() && is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
-              if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
-                s = s.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(s[colon - 1])) {
-                s = std::string("0") + s.substr(colon - 1, 4);
-              } else {
-                s = "--";
-              }
-            } else {
-              s = "--";
-            }
-            return s;
+            return id(printer_start_time_display).state;
 
       - lvgl.label.update:
           id: end_value
           text: !lambda |-
-            if (id(printer_end_time).state.empty() || id(printer_end_time).state == "unknown" || id(printer_end_time).state == "unavailable") {
-              return std::string("--");
-            }
-            std::string e = id(printer_end_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = e.find(':');
-            if (colon != std::string::npos && colon + 2 < e.size() && is_digit(e[colon + 1]) && is_digit(e[colon + 2])) {
-              if (colon >= 2 && is_digit(e[colon - 2]) && is_digit(e[colon - 1])) {
-                e = e.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(e[colon - 1])) {
-                e = std::string("0") + e.substr(colon - 1, 4);
-              } else {
-                e = "--";
-              }
-            } else {
-              e = "--";
-            }
-            return e;
+            return id(printer_end_time_display).state;
 
       - lvgl.label.update:
           id: power_value
@@ -2055,46 +2173,12 @@ script:
       - lvgl.label.update:
           id: monitor_start
           text: !lambda |-
-            if (id(printer_start_time).state.empty() || id(printer_start_time).state == "unknown" || id(printer_start_time).state == "unavailable") {
-              return std::string("--");
-            }
-            std::string s = id(printer_start_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = s.find(':');
-            if (colon != std::string::npos && colon + 2 < s.size() && is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
-              if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
-                s = s.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(s[colon - 1])) {
-                s = std::string("0") + s.substr(colon - 1, 4);
-              } else {
-                s = "--";
-              }
-            } else {
-              s = "--";
-            }
-            return s;
+            return id(printer_start_time_display).state;
 
       - lvgl.label.update:
           id: monitor_end
           text: !lambda |-
-            if (id(printer_end_time).state.empty() || id(printer_end_time).state == "unknown" || id(printer_end_time).state == "unavailable") {
-              return std::string("--");
-            }
-            std::string e = id(printer_end_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = e.find(':');
-            if (colon != std::string::npos && colon + 2 < e.size() && is_digit(e[colon + 1]) && is_digit(e[colon + 2])) {
-              if (colon >= 2 && is_digit(e[colon - 2]) && is_digit(e[colon - 1])) {
-                e = e.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(e[colon - 1])) {
-                e = std::string("0") + e.substr(colon - 1, 4);
-              } else {
-                e = "--";
-              }
-            } else {
-              e = "--";
-            }
-            return e;
+            return id(printer_end_time_display).state;
 
       - lvgl.label.update:
           id: monitor_wifi
@@ -2625,46 +2709,12 @@ script:
       - lvgl.label.update:
           id: orbit_start
           text: !lambda |-
-            if (id(printer_start_time).state.empty() || id(printer_start_time).state == "unknown" || id(printer_start_time).state == "unavailable") {
-              return std::string("S --");
-            }
-            std::string s = id(printer_start_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = s.find(':');
-            if (colon != std::string::npos && colon + 2 < s.size() && is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
-              if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
-                s = s.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(s[colon - 1])) {
-                s = std::string("0") + s.substr(colon - 1, 4);
-              } else {
-                s = "--";
-              }
-            } else {
-              s = "--";
-            }
-            return std::string("S ") + s;
+            return std::string("S ") + id(printer_start_time_display).state;
 
       - lvgl.label.update:
           id: orbit_end
           text: !lambda |-
-            if (id(printer_end_time).state.empty() || id(printer_end_time).state == "unknown" || id(printer_end_time).state == "unavailable") {
-              return std::string("E --");
-            }
-            std::string e = id(printer_end_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = e.find(':');
-            if (colon != std::string::npos && colon + 2 < e.size() && is_digit(e[colon + 1]) && is_digit(e[colon + 2])) {
-              if (colon >= 2 && is_digit(e[colon - 2]) && is_digit(e[colon - 1])) {
-                e = e.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(e[colon - 1])) {
-                e = std::string("0") + e.substr(colon - 1, 4);
-              } else {
-                e = "--";
-              }
-            } else {
-              e = "--";
-            }
-            return std::string("E ") + e;
+            return std::string("E ") + id(printer_end_time_display).state;
 
       - lvgl.label.update:
           id: orbit_power
@@ -2801,46 +2851,12 @@ script:
       - lvgl.label.update:
           id: blueprint_start
           text: !lambda |-
-            if (id(printer_start_time).state.empty() || id(printer_start_time).state == "unknown" || id(printer_start_time).state == "unavailable") {
-              return std::string("S --");
-            }
-            std::string s = id(printer_start_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = s.find(':');
-            if (colon != std::string::npos && colon + 2 < s.size() && is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
-              if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
-                s = s.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(s[colon - 1])) {
-                s = std::string("0") + s.substr(colon - 1, 4);
-              } else {
-                s = "--";
-              }
-            } else {
-              s = "--";
-            }
-            return std::string("S ") + s;
+            return std::string("S ") + id(printer_start_time_display).state;
 
       - lvgl.label.update:
           id: blueprint_end
           text: !lambda |-
-            if (id(printer_end_time).state.empty() || id(printer_end_time).state == "unknown" || id(printer_end_time).state == "unavailable") {
-              return std::string("E --");
-            }
-            std::string e = id(printer_end_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = e.find(':');
-            if (colon != std::string::npos && colon + 2 < e.size() && is_digit(e[colon + 1]) && is_digit(e[colon + 2])) {
-              if (colon >= 2 && is_digit(e[colon - 2]) && is_digit(e[colon - 1])) {
-                e = e.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(e[colon - 1])) {
-                e = std::string("0") + e.substr(colon - 1, 4);
-              } else {
-                e = "--";
-              }
-            } else {
-              e = "--";
-            }
-            return std::string("E ") + e;
+            return std::string("E ") + id(printer_end_time_display).state;
 
       - lvgl.label.update:
           id: brutal_clock
@@ -2962,46 +2978,12 @@ script:
       - lvgl.label.update:
           id: brutal_start
           text: !lambda |-
-            if (id(printer_start_time).state.empty() || id(printer_start_time).state == "unknown" || id(printer_start_time).state == "unavailable") {
-              return std::string("S --");
-            }
-            std::string s = id(printer_start_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = s.find(':');
-            if (colon != std::string::npos && colon + 2 < s.size() && is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
-              if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
-                s = s.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(s[colon - 1])) {
-                s = std::string("0") + s.substr(colon - 1, 4);
-              } else {
-                s = "--";
-              }
-            } else {
-              s = "--";
-            }
-            return std::string("S ") + s;
+            return std::string("S ") + id(printer_start_time_display).state;
 
       - lvgl.label.update:
           id: brutal_end
           text: !lambda |-
-            if (id(printer_end_time).state.empty() || id(printer_end_time).state == "unknown" || id(printer_end_time).state == "unavailable") {
-              return std::string("E --");
-            }
-            std::string e = id(printer_end_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = e.find(':');
-            if (colon != std::string::npos && colon + 2 < e.size() && is_digit(e[colon + 1]) && is_digit(e[colon + 2])) {
-              if (colon >= 2 && is_digit(e[colon - 2]) && is_digit(e[colon - 1])) {
-                e = e.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(e[colon - 1])) {
-                e = std::string("0") + e.substr(colon - 1, 4);
-              } else {
-                e = "--";
-              }
-            } else {
-              e = "--";
-            }
-            return std::string("E ") + e;
+            return std::string("E ") + id(printer_end_time_display).state;
 
       - lvgl.label.update:
           id: apple_clock
@@ -3123,46 +3105,12 @@ script:
       - lvgl.label.update:
           id: apple_start
           text: !lambda |-
-            if (id(printer_start_time).state.empty() || id(printer_start_time).state == "unknown" || id(printer_start_time).state == "unavailable") {
-              return std::string("S --");
-            }
-            std::string s = id(printer_start_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = s.find(':');
-            if (colon != std::string::npos && colon + 2 < s.size() && is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
-              if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
-                s = s.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(s[colon - 1])) {
-                s = std::string("0") + s.substr(colon - 1, 4);
-              } else {
-                s = "--";
-              }
-            } else {
-              s = "--";
-            }
-            return std::string("S ") + s;
+            return std::string("S ") + id(printer_start_time_display).state;
 
       - lvgl.label.update:
           id: apple_end
           text: !lambda |-
-            if (id(printer_end_time).state.empty() || id(printer_end_time).state == "unknown" || id(printer_end_time).state == "unavailable") {
-              return std::string("E --");
-            }
-            std::string e = id(printer_end_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = e.find(':');
-            if (colon != std::string::npos && colon + 2 < e.size() && is_digit(e[colon + 1]) && is_digit(e[colon + 2])) {
-              if (colon >= 2 && is_digit(e[colon - 2]) && is_digit(e[colon - 1])) {
-                e = e.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(e[colon - 1])) {
-                e = std::string("0") + e.substr(colon - 1, 4);
-              } else {
-                e = "--";
-              }
-            } else {
-              e = "--";
-            }
-            return std::string("E ") + e;
+            return std::string("E ") + id(printer_end_time_display).state;
 
       - lvgl.label.update:
           id: grid_clock
@@ -3284,46 +3232,12 @@ script:
       - lvgl.label.update:
           id: grid_start
           text: !lambda |-
-            if (id(printer_start_time).state.empty() || id(printer_start_time).state == "unknown" || id(printer_start_time).state == "unavailable") {
-              return std::string("S --");
-            }
-            std::string s = id(printer_start_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = s.find(':');
-            if (colon != std::string::npos && colon + 2 < s.size() && is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
-              if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
-                s = s.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(s[colon - 1])) {
-                s = std::string("0") + s.substr(colon - 1, 4);
-              } else {
-                s = "--";
-              }
-            } else {
-              s = "--";
-            }
-            return std::string("S ") + s;
+            return std::string("S ") + id(printer_start_time_display).state;
 
       - lvgl.label.update:
           id: grid_end
           text: !lambda |-
-            if (id(printer_end_time).state.empty() || id(printer_end_time).state == "unknown" || id(printer_end_time).state == "unavailable") {
-              return std::string("E --");
-            }
-            std::string e = id(printer_end_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = e.find(':');
-            if (colon != std::string::npos && colon + 2 < e.size() && is_digit(e[colon + 1]) && is_digit(e[colon + 2])) {
-              if (colon >= 2 && is_digit(e[colon - 2]) && is_digit(e[colon - 1])) {
-                e = e.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(e[colon - 1])) {
-                e = std::string("0") + e.substr(colon - 1, 4);
-              } else {
-                e = "--";
-              }
-            } else {
-              e = "--";
-            }
-            return std::string("E ") + e;
+            return std::string("E ") + id(printer_end_time_display).state;
 
       - lvgl.label.update:
           id: skeuo_clock
@@ -3445,46 +3359,12 @@ script:
       - lvgl.label.update:
           id: skeuo_start
           text: !lambda |-
-            if (id(printer_start_time).state.empty() || id(printer_start_time).state == "unknown" || id(printer_start_time).state == "unavailable") {
-              return std::string("S --");
-            }
-            std::string s = id(printer_start_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = s.find(':');
-            if (colon != std::string::npos && colon + 2 < s.size() && is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
-              if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
-                s = s.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(s[colon - 1])) {
-                s = std::string("0") + s.substr(colon - 1, 4);
-              } else {
-                s = "--";
-              }
-            } else {
-              s = "--";
-            }
-            return std::string("S ") + s;
+            return std::string("S ") + id(printer_start_time_display).state;
 
       - lvgl.label.update:
           id: skeuo_end
           text: !lambda |-
-            if (id(printer_end_time).state.empty() || id(printer_end_time).state == "unknown" || id(printer_end_time).state == "unavailable") {
-              return std::string("E --");
-            }
-            std::string e = id(printer_end_time).state;
-            auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-            size_t colon = e.find(':');
-            if (colon != std::string::npos && colon + 2 < e.size() && is_digit(e[colon + 1]) && is_digit(e[colon + 2])) {
-              if (colon >= 2 && is_digit(e[colon - 2]) && is_digit(e[colon - 1])) {
-                e = e.substr(colon - 2, 5);
-              } else if (colon >= 1 && is_digit(e[colon - 1])) {
-                e = std::string("0") + e.substr(colon - 1, 4);
-              } else {
-                e = "--";
-              }
-            } else {
-              e = "--";
-            }
-            return std::string("E ") + e;
+            return std::string("E ") + id(printer_end_time_display).state;
 
   - id: show_toast
     mode: restart

--- a/packages/cyd-dashboard.yaml
+++ b/packages/cyd-dashboard.yaml
@@ -622,6 +622,10 @@ text_sensor:
           }
         }
       }
+      if (!is_utc && s.size() >= 10 && s[4] == '-' && s[7] == '-' &&
+          s[0] >= '0' && s[0] <= '9') {
+        is_utc = true;
+      }
 
       ESPTime parsed;
       if (ESPTime::strptime(s, parsed)) {
@@ -657,6 +661,16 @@ text_sensor:
     internal: true
     update_interval: 1s
     lambda: |-
+      const auto now = id(ha_time).now();
+      const float remaining = id(printer_time_left).state;
+      if (now.is_valid() && !isnan(remaining) && remaining > 0.0f) {
+        const time_t end_ts = now.timestamp + static_cast<time_t>(remaining * 60.0f);
+        const ESPTime end_local = ESPTime::from_epoch_local(end_ts);
+        char buf[8];
+        snprintf(buf, sizeof(buf), "%02d:%02d", end_local.hour, end_local.minute);
+        return std::string(buf);
+      }
+
       const std::string raw = id(printer_end_time).state;
       if (raw.empty() || raw == "unknown" || raw == "unavailable") {
         return std::string("--");
@@ -697,6 +711,10 @@ text_sensor:
             s.pop_back();
           }
         }
+      }
+      if (!is_utc && s.size() >= 10 && s[4] == '-' && s[7] == '-' &&
+          s[0] >= '0' && s[0] <= '9') {
+        is_utc = true;
       }
 
       ESPTime parsed;

--- a/packages/cyd-dashboard.yaml
+++ b/packages/cyd-dashboard.yaml
@@ -646,88 +646,45 @@ text_sensor:
     update_interval: 1s
     lambda: |-
       const auto now = id(ha_time).now();
-      const float remaining = id(printer_time_left).state;
-      if (now.is_valid() && !isnan(remaining) && remaining > 0.0f) {
-        const time_t end_ts = now.timestamp + static_cast<time_t>(remaining * 60.0f);
+      if (!now.is_valid()) {
+        return std::string("--");
+      }
+
+      float remaining = id(printer_time_left).state;
+      if (isnan(remaining) || remaining < 0.0f) {
+        remaining = 0.0f;
+      }
+
+      std::string unit = id(printer_time_left_unit).state;
+      for (char &c : unit) {
+        if (c >= 'A' && c <= 'Z') {
+          c = static_cast<char>(c - 'A' + 'a');
+        }
+      }
+
+      int total_minutes = 0;
+      if (unit.find("jour") != std::string::npos || unit.find("day") != std::string::npos || unit == "d") {
+        total_minutes = static_cast<int>(remaining * 1440.0f + 0.5f);
+      } else if (unit.find("heure") != std::string::npos || unit.find("hour") != std::string::npos || unit == "h" || unit == "hr" || unit == "hrs") {
+        total_minutes = static_cast<int>(remaining * 60.0f + 0.5f);
+      } else if (unit.find("sec") != std::string::npos || unit == "s") {
+        total_minutes = static_cast<int>(remaining / 60.0f + 0.5f);
+      } else if (unit.find("min") != std::string::npos || unit == "m") {
+        total_minutes = static_cast<int>(remaining + 0.5f);
+      } else if (remaining > 0.0f && remaining <= 24.0f) {
+        total_minutes = static_cast<int>(remaining * 60.0f + 0.5f);
+      } else {
+        total_minutes = static_cast<int>(remaining + 0.5f);
+      }
+
+      if (total_minutes > 0) {
+        const time_t end_ts = now.timestamp + static_cast<time_t>(total_minutes) * 60;
         const ESPTime end_local = ESPTime::from_epoch_local(end_ts);
         char buf[8];
         snprintf(buf, sizeof(buf), "%02d:%02d", end_local.hour, end_local.minute);
         return std::string(buf);
       }
 
-      const std::string raw = id(printer_end_time).state;
-      if (raw.empty() || raw == "unknown" || raw == "unavailable") {
-        return std::string("--");
-      }
-
-      std::string s = raw;
-      for (char &c : s) {
-        if (c == 'T') {
-          c = ' ';
-        }
-      }
-
-      const size_t dot = s.find('.');
-      if (dot != std::string::npos) {
-        s = s.substr(0, dot);
-      }
-
-      bool is_utc = false;
-      if (!s.empty() && s.back() == 'Z') {
-        is_utc = true;
-        s.pop_back();
-        while (!s.empty() && s.back() == ' ') {
-          s.pop_back();
-        }
-      }
-      if (s.size() >= 6) {
-        const size_t pos = s.size() - 6;
-        const char sign = s[pos];
-        if ((sign == '+' || sign == '-') &&
-            s[pos + 1] >= '0' && s[pos + 1] <= '9' &&
-            s[pos + 2] >= '0' && s[pos + 2] <= '9' &&
-            s[pos + 3] == ':' &&
-            s[pos + 4] >= '0' && s[pos + 4] <= '9' &&
-            s[pos + 5] >= '0' && s[pos + 5] <= '9') {
-          is_utc = true;
-          s = s.substr(0, pos);
-          while (!s.empty() && s.back() == ' ') {
-            s.pop_back();
-          }
-        }
-      }
-      if (!is_utc && s.size() >= 10 && s[4] == '-' && s[7] == '-' &&
-          s[0] >= '0' && s[0] <= '9') {
-        is_utc = true;
-      }
-
-      ESPTime parsed;
-      if (ESPTime::strptime(s, parsed)) {
-        if (is_utc && parsed.year >= 2019) {
-          parsed.recalc_timestamp_utc();
-          if (parsed.timestamp >= 0) {
-            const ESPTime local = ESPTime::from_epoch_local(parsed.timestamp);
-            char buf[8];
-            snprintf(buf, sizeof(buf), "%02d:%02d", local.hour, local.minute);
-            return std::string(buf);
-          }
-        }
-        char buf[8];
-        snprintf(buf, sizeof(buf), "%02d:%02d", parsed.hour, parsed.minute);
-        return std::string(buf);
-      }
-
-      auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-      const size_t colon = s.find(':');
-      if (colon != std::string::npos && colon + 2 < s.size() &&
-          is_digit(s[colon + 1]) && is_digit(s[colon + 2])) {
-        if (colon >= 2 && is_digit(s[colon - 2]) && is_digit(s[colon - 1])) {
-          return s.substr(colon - 2, 5);
-        }
-        if (colon >= 1 && is_digit(s[colon - 1])) {
-          return std::string("0") + s.substr(colon - 1, 4);
-        }
-      }
       return std::string("--");
 
   - platform: template


### PR DESCRIPTION
## Summary

- Fixes #3 — print start/end times now display in the Home Assistant local timezone, matching the header clock.
- Bambu Lab `start_time` / `end_time` sensors expose UTC ISO timestamps; the dashboard previously extracted `HH:MM` from the raw string without conversion.
- Treat ISO datetimes without an explicit offset as UTC (Home Assistant often omits the suffix when forwarding state to ESPHome).
- Derive end time from `now + remaining` during active prints so it always matches the ETA.

## Test plan

- [ ] Recompile and flash the updated dashboard package
- [ ] During an active print, compare CYD start/end times with Home Assistant (local timezone)
- [ ] Confirm end time matches clock + remaining (e.g. 19:57 + 17 min → 20:14 in BST)
- [ ] Confirm `--` still shows when no print is active
- [ ] Spot-check at least two themes (e.g. Tactical and Monitor)